### PR TITLE
fix: add missing includes

### DIFF
--- a/src/usb2dynamixel/LayoutPart.h
+++ b/src/usb2dynamixel/LayoutPart.h
@@ -2,8 +2,10 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <functional>
+#include <map>
 #include <map>
 #include <optional>
 #include <stdexcept>


### PR DESCRIPTION
To compile inspexel for gcc13.2 some includes where missing.